### PR TITLE
LWSHADOOP-749: Prep solr-hadoop-common for Hadoop3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 project(":solr-hadoop-common:solr-hadoop-document") {
 
     dependencies {
-        compile("org.apache.hadoop:hadoop-client:${hadoop2Version}") {
+        compile("org.apache.hadoop:hadoop-client:${hadoopVersion}") {
             exclude group: "org.fusesource.leveldbjni"
             exclude group: "aopalliance"
             exclude group: "org.apache.avro"
@@ -33,7 +33,7 @@ project(":solr-hadoop-common:solr-hadoop-io") {
 
     dependencies {
         compile("org.apache.solr:solr-solrj:${solrVersion}")
-        compile("org.apache.hadoop:hadoop-client:${hadoop2Version}")
+        compile("org.apache.hadoop:hadoop-client:${hadoopVersion}")
         compile "com.google.inject:guice:3.0"
 
         testCompile 'junit:junit:4.12'
@@ -55,7 +55,7 @@ project(":solr-hadoop-common:solr-hadoop-testbase") {
 
         compile(project(':solr-hadoop-common:solr-hadoop-document')) {
         }
-        compile "org.apache.hadoop:hadoop-client:${hadoop2Version}"
+        compile "org.apache.hadoop:hadoop-client:${hadoopVersion}"
         compile "org.apache.solr:solr-test-framework:${solrVersion}"
     }
 }

--- a/solr-hadoop-document/src/main/java/com/lucidworks/hadoop/io/impl/LWSolrDocument.java
+++ b/solr-hadoop-document/src/main/java/com/lucidworks/hadoop/io/impl/LWSolrDocument.java
@@ -1,13 +1,12 @@
 package com.lucidworks.hadoop.io.impl;
 
+import com.fasterxml.jackson.databind.*;
+
 import com.lucidworks.hadoop.io.LWDocument;
 
 import org.apache.hadoop.io.Text;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -195,9 +194,9 @@ public class LWSolrDocument implements LWDocument {
 
   private static ObjectMapper createMapper() {
     ObjectMapper mapper = new ObjectMapper();
-    mapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
-    mapper.configure(SerializationConfig.Feature.FAIL_ON_EMPTY_BEANS, false);
-    mapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     final DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     df.setTimeZone(TimeZone.getTimeZone("UTC"));

--- a/solr-hadoop-io/src/main/java/com/lucidworks/hadoop/io/LucidWorksWriter.java
+++ b/solr-hadoop-io/src/main/java/com/lucidworks/hadoop/io/LucidWorksWriter.java
@@ -2,7 +2,7 @@ package com.lucidworks.hadoop.io;
 
 import com.lucidworks.hadoop.security.SolrSecurity;
 
-import org.apache.commons.httpclient.NoHttpResponseException;
+import org.apache.http.NoHttpResponseException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.net.ConnectTimeoutException;


### PR DESCRIPTION
This commit allows solr-hadoop-common to compile/run against a
hadoopVersion of 3.0.0.  (Consuming projects who are ready for this
change can create a `hadoopVersion` property with this value, and update
their `solr-hadoop-common` reference commit.)