### PR TITLE
Ignore default IntelliJ test-output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .gradle
 *.iml
+**/out/


### PR DESCRIPTION
Some IntelliJ configurations create`/out/` directories under each
submodule when running tests.  These won't ever need to be tracked
by version control, and are otherwise just a distraction, so this
commit adds any directories matching this pattern to our .gitignore.