### PR TITLE
LWSHADOOP-749: Explicitly declare jackson dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ project(":solr-hadoop-common:solr-hadoop-document") {
             exclude group: "com.sun.jersey"
             exclude group: "log4j"
         }
+        compile("com.fasterxml.jackson.core:jackson-databind:2.7.8")
         compile("org.apache.solr:solr-solrj:${solrVersion}") {
             transitive = false
         }
@@ -35,6 +36,7 @@ project(":solr-hadoop-common:solr-hadoop-io") {
         compile("org.apache.solr:solr-solrj:${solrVersion}")
         compile("org.apache.hadoop:hadoop-client:${hadoop2Version}")
         compile "com.google.inject:guice:3.0"
+        compile("com.fasterxml.jackson.core:jackson-databind:2.7.8")
 
         testCompile 'junit:junit:4.12'
         testCompile 'com.carrotsearch.randomizedtesting:junit4-ant:1.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ project(":solr-hadoop-common:solr-hadoop-io") {
         compile("org.apache.hadoop:hadoop-client:${hadoop2Version}")
         compile "com.google.inject:guice:3.0"
         compile("com.fasterxml.jackson.core:jackson-databind:2.7.8")
+        compile("org.apache.httpcomponents:httpcore:4.4.6")
 
         testCompile 'junit:junit:4.12'
         testCompile 'com.carrotsearch.randomizedtesting:junit4-ant:1.4.0'

--- a/solr-hadoop-document/src/main/java/com/lucidworks/hadoop/io/impl/LWSolrDocument.java
+++ b/solr-hadoop-document/src/main/java/com/lucidworks/hadoop/io/impl/LWSolrDocument.java
@@ -5,9 +5,7 @@ import com.lucidworks.hadoop.io.LWDocument;
 import org.apache.hadoop.io.Text;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
+import com.fasterxml.jackson.databind.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -195,9 +193,9 @@ public class LWSolrDocument implements LWDocument {
 
   private static ObjectMapper createMapper() {
     ObjectMapper mapper = new ObjectMapper();
-    mapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
-    mapper.configure(SerializationConfig.Feature.FAIL_ON_EMPTY_BEANS, false);
-    mapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     final DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     df.setTimeZone(TimeZone.getTimeZone("UTC"));

--- a/solr-hadoop-io/src/main/java/com/lucidworks/hadoop/io/LucidWorksWriter.java
+++ b/solr-hadoop-io/src/main/java/com/lucidworks/hadoop/io/LucidWorksWriter.java
@@ -2,7 +2,7 @@ package com.lucidworks.hadoop.io;
 
 import com.lucidworks.hadoop.security.SolrSecurity;
 
-import org.apache.commons.httpclient.NoHttpResponseException;
+import org.apache.http.NoHttpResponseException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.net.ConnectTimeoutException;


### PR DESCRIPTION
Certain classes in `solr-hadoop-common` (specifically, LWSolrDocument)
make use Jackson APIs, but nothing in the project's gradle file declares
its reliance on this dependency.  This means that we're implicitly
relying on one of our other dependencies (hadoop) to pull it in transitively.

This is misleading and trappy.  It also causes opens the door to build
failures, as we allow our consumers to pick their own hadoop version.

This commit declares our dependence on Jackson in our build.gradle.