### PR TITLE
LWSHADOOP-749: Add Hadoop 2,3 deps to different gradle configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,20 @@
 project(":solr-hadoop-common:solr-hadoop-document") {
 
     dependencies {
-        compile("org.apache.hadoop:hadoop-client:${hadoop2Version}") {
+        hadoop2Compile("org.apache.hadoop:hadoop-client:${hadoop2Version}") {
+            exclude group: "org.fusesource.leveldbjni"
+            exclude group: "aopalliance"
+            exclude group: "org.apache.avro"
+            exclude group: "org.apache.zookeeper"
+            exclude group: "org.mortbay.jetty"
+            exclude group: "org.apache.httpcomponents"
+            exclude group: "com.google.protobuf"
+            exclude group: "io.netty"
+            exclude group: "jline"
+            exclude group: "com.sun.jersey"
+            exclude group: "log4j"
+        }
+        hadoop3Compile("org.apache.hadoop:hadoop-client:${hadoop3Version}") {
             exclude group: "org.fusesource.leveldbjni"
             exclude group: "aopalliance"
             exclude group: "org.apache.avro"
@@ -34,7 +47,8 @@ project(":solr-hadoop-common:solr-hadoop-io") {
 
     dependencies {
         compile("org.apache.solr:solr-solrj:${solrVersion}")
-        compile("org.apache.hadoop:hadoop-client:${hadoop2Version}")
+        hadoop2Compile("org.apache.hadoop:hadoop-client:${hadoop2Version}")
+        hadoop3Compile("org.apache.hadoop:hadoop-client:${hadoop3Version}")
         compile "com.google.inject:guice:3.0"
         compile("com.fasterxml.jackson.core:jackson-databind:2.7.8")
         compile("org.apache.httpcomponents:httpcore:4.4.6")
@@ -58,7 +72,8 @@ project(":solr-hadoop-common:solr-hadoop-testbase") {
 
         compile(project(':solr-hadoop-common:solr-hadoop-document')) {
         }
-        compile "org.apache.hadoop:hadoop-client:${hadoop2Version}"
+        hadoop2Compile "org.apache.hadoop:hadoop-client:${hadoop2Version}"
+        hadoop3Compile "org.apache.hadoop:hadoop-client:${hadoop3Version}"
         compile "org.apache.solr:solr-test-framework:${solrVersion}"
     }
 }


### PR DESCRIPTION
Prior to this commit, solr-hadoop-commons chose the Hadoop version to
build against based on the `hadoop2Version` property set in the parent
repository.

On one hand this approach is very flexible.  But on the other, it means
that parent projects can only compile against a single Hadoop version
per build.  A user would have tweak the property themselves and run
multiple times to cover multiple Hadoop versions.

This commit alters this by pulling down each Hadoop dependency in two
difference flavors: a Hadoop 2 version (specified by gradle property:
`hadoop2Version`), and a Hadoop 3 version (specified by gradle property:
`hadoop3Version`).  These dependencies are then assigned to different
gradle configurations.

This allows parent projects to build against both Hadoop major versions,
if they so choose.  If they prefer not to, they can just choose a single
gradle configuration to use instead.