### PR TITLE
LWSHADOOP-565: Make Hadoop config profiles optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,31 +1,35 @@
 project(":solr-hadoop-common:solr-hadoop-document") {
 
     dependencies {
-        hadoop2Compile("org.apache.hadoop:hadoop-client:${hadoop2Version}") {
-            exclude group: "org.fusesource.leveldbjni"
-            exclude group: "aopalliance"
-            exclude group: "org.apache.avro"
-            exclude group: "org.apache.zookeeper"
-            exclude group: "org.mortbay.jetty"
-            exclude group: "org.apache.httpcomponents"
-            exclude group: "com.google.protobuf"
-            exclude group: "io.netty"
-            exclude group: "jline"
-            exclude group: "com.sun.jersey"
-            exclude group: "log4j"
+        if (project.hasProperty("hadoop2Version")) {
+            hadoop2Compile("org.apache.hadoop:hadoop-client:${hadoop2Version}") {
+                exclude group: "org.fusesource.leveldbjni"
+                exclude group: "aopalliance"
+                exclude group: "org.apache.avro"
+                exclude group: "org.apache.zookeeper"
+                exclude group: "org.mortbay.jetty"
+                exclude group: "org.apache.httpcomponents"
+                exclude group: "com.google.protobuf"
+                exclude group: "io.netty"
+                exclude group: "jline"
+                exclude group: "com.sun.jersey"
+                exclude group: "log4j"
+            }
         }
-        hadoop3Compile("org.apache.hadoop:hadoop-client:${hadoop3Version}") {
-            exclude group: "org.fusesource.leveldbjni"
-            exclude group: "aopalliance"
-            exclude group: "org.apache.avro"
-            exclude group: "org.apache.zookeeper"
-            exclude group: "org.mortbay.jetty"
-            exclude group: "org.apache.httpcomponents"
-            exclude group: "com.google.protobuf"
-            exclude group: "io.netty"
-            exclude group: "jline"
-            exclude group: "com.sun.jersey"
-            exclude group: "log4j"
+        if (project.hasProperty("hadoop3Version")) {
+            hadoop3Compile("org.apache.hadoop:hadoop-client:${hadoop3Version}") {
+                exclude group: "org.fusesource.leveldbjni"
+                exclude group: "aopalliance"
+                exclude group: "org.apache.avro"
+                exclude group: "org.apache.zookeeper"
+                exclude group: "org.mortbay.jetty"
+                exclude group: "org.apache.httpcomponents"
+                exclude group: "com.google.protobuf"
+                exclude group: "io.netty"
+                exclude group: "jline"
+                exclude group: "com.sun.jersey"
+                exclude group: "log4j"
+            }
         }
         compile("com.fasterxml.jackson.core:jackson-databind:2.7.8")
         compile("org.apache.solr:solr-solrj:${solrVersion}") {
@@ -47,8 +51,12 @@ project(":solr-hadoop-common:solr-hadoop-io") {
 
     dependencies {
         compile("org.apache.solr:solr-solrj:${solrVersion}")
-        hadoop2Compile("org.apache.hadoop:hadoop-client:${hadoop2Version}")
-        hadoop3Compile("org.apache.hadoop:hadoop-client:${hadoop3Version}")
+        if (project.hasProperty("hadoop2Version")) {
+            hadoop2Compile("org.apache.hadoop:hadoop-client:${hadoop2Version}")
+        }
+        if (project.hasProperty("hadoop3Version")) {
+            hadoop3Compile("org.apache.hadoop:hadoop-client:${hadoop3Version}")
+        }
         compile "com.google.inject:guice:3.0"
         compile("com.fasterxml.jackson.core:jackson-databind:2.7.8")
         compile("org.apache.httpcomponents:httpcore:4.4.6")
@@ -72,8 +80,12 @@ project(":solr-hadoop-common:solr-hadoop-testbase") {
 
         compile(project(':solr-hadoop-common:solr-hadoop-document')) {
         }
-        hadoop2Compile "org.apache.hadoop:hadoop-client:${hadoop2Version}"
-        hadoop3Compile "org.apache.hadoop:hadoop-client:${hadoop3Version}"
+        if (project.hasProperty("hadoop2Version")) {
+            hadoop2Compile "org.apache.hadoop:hadoop-client:${hadoop2Version}"
+        }
+        if (project.hasProperty("hadoop3Version")) {
+            hadoop3Compile "org.apache.hadoop:hadoop-client:${hadoop3Version}"
+        }
         compile "org.apache.solr:solr-test-framework:${solrVersion}"
     }
 }


### PR DESCRIPTION
Prior to this commit, solr-hadoop-common consumers were required to
setup both a hadoop2Version and a hadoop3Version dependency configuration.

This made sense in the context of the hadoop-solr job-jar, which drove
these changes, but doesn't make sense for all consumers.  Some parent
modules will need separate branches to support Hadoop 2/3.  Others may
just not be interested in building/testing both simultaneously.

This commit alters the dependency declarations in solr-hadoop-common
to only be invoked if the 'hadoop2Version' or 'hadoop3Version' is
defined, respectively.  This gives solr-hadoop-common the flexibility
to be consumed by projects that just care about just one of the two, or
about both.