### PR TITLE
LWSHADOOP-703: Upgrade 'shadow' plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ project(":solr-hadoop-common:solr-hadoop-tika") {
     publishing {
         publications {
             shadow(MavenPublication) {
-                from components.shadow
+                project.shadow.component(it)
             }
         }
     }


### PR DESCRIPTION
Some gradle config in solr-hadoop-common used 'shadow' APIs that were only available in older versions of the plugin.  This commit updates these usages to the more modern (v2.x) usages, so that we can start to take advantage of bug-fixes in the shadow plugin.

(The version of the 'shadow' plugin is defined by most in the consumer `build.gradle`.  Projects upgrading their `solr-hadoop-common` to this version will need to bump their shadow plugin declaration to v2.0.0 or higher.) 